### PR TITLE
Ignore node_modules/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Hello,

I think it will be good to ignore `node_modules/` because of installation from local directory.
I store your repo as submodule in my `dotfiles` repository so I have permanently untracked files.

Thanks
